### PR TITLE
Fix Docker build failure due to missing packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,12 @@ WORKDIR /app
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
-    libgl1-mesa-glx \
-    libglib2.0-0 \
+    libgl1 \
+    libglib2.0-0t64 \
     libsm6 \
     libxext6 \
     libxrender-dev \
     libgomp1 \
-    libgthread-2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching


### PR DESCRIPTION
The base image `python:3.11-slim` uses Debian `trixie`, where some package names have changed.

- Replaced `libgl1-mesa-glx` with `libgl1`.
- Replaced `libglib2.0-0` with `libglib2.0-0t64`.
- Removed `libgthread-2.0-0` as its functionality is included in `libglib2.0-0t64`.