### PR TITLE
Fix: Handle RGBA images in color analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Test files
+images/looks/test_rgba.png

--- a/utils/color_analysis.py
+++ b/utils/color_analysis.py
@@ -43,12 +43,12 @@ class ColorAnalyzer:
         else:
             image_array = image
             
+        # Remove any alpha channel before reshaping
+        if image_array.ndim == 3 and image_array.shape[2] == 4:
+            image_array = image_array[:, :, :3]
+
         # Reshape image to be a list of pixels
         pixels = image_array.reshape((-1, 3))
-        
-        # Remove any alpha channel
-        if pixels.shape[1] > 3:
-            pixels = pixels[:, :3]
         
         # Apply K-means clustering
         kmeans = KMeans(n_clusters=n_colors, random_state=42, n_init='auto')


### PR DESCRIPTION
The `extract_dominant_colors` function in `utils/color_analysis.py` was failing with a `ValueError` when processing images with an alpha channel (RGBA). This was because the code was attempting to reshape the image array to 3 channels before stripping the alpha channel.

This commit fixes the issue by moving the alpha channel removal logic to before the reshape operation. It now correctly checks for a 4th channel and slices the array to RGB before reshaping, preventing the error.